### PR TITLE
Implement websocket to receive measurement messages

### DIFF
--- a/fkie_measurement_server/fkie_measurement_server/__init__.py
+++ b/fkie_measurement_server/fkie_measurement_server/__init__.py
@@ -15,7 +15,28 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import fkie_measurement_server
+import sys
 
-if __name__ == '__main__':
-    fkie_measurement_server.main()
+from fkie_measurement_server.measurement_server import MeasurementCollectorNode
+
+import rclpy
+import rclpy.executors
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MeasurementCollectorNode()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, rclpy.executors.ExternalShutdownException):
+        pass
+    except Exception as err:
+        import traceback
+
+        print(traceback.format_exc())
+        print("Error while initialize ROS-Node: %s" % (err), file=sys.stderr)
+    finally:
+        print("Shutdown...")
+        node.stop()
+        node.destroy_node()
+        print("Bye!")

--- a/fkie_measurement_server/fkie_measurement_server/commands.py
+++ b/fkie_measurement_server/fkie_measurement_server/commands.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#  Copyright 2025 Fraunhofer FKIE - All Rights Reserved
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from fkie_measurement_server_msgs.msg import CommandIn, CommandOut
+from fkie_measurement_msgs.msg import MeasurementArray
+
+
+class CommandManager:
+    def __init__(self, node=None):
+        self.node = node
+
+        self.node.get_logger().info(" ")
+        self.node.get_logger().info("Initializing Command Manager...")
+
+        self.commandin = self.node.create_subscription(
+            CommandIn, self.node.topic_command_in, self.callback_command, 5
+        )
+        self.node.get_logger().info(f"Subscribed to {self.commandin.topic_name}")
+
+        self.commandout = self.node.create_publisher(
+            CommandOut, self.node.topic_command_out, 5
+        )
+        self.node.get_logger().info(f"Advertising to {self.commandout.topic_name}")
+
+        self.node.get_logger().info("Command Manager Initialized.")
+
+    def callback_command(self, msg):
+        self.node.get_logger().info(f"Command called: {msg.command}")
+        match msg.command:
+            case "history":
+                history = MeasurementArray()
+                history.full_history = True
+                for _id, ma in self.node.sensor_histories.items():
+                    history.measurements.extend(ma.measurements)
+                    history.located_measurements.extend(ma.located_measurements)
+                self.node.pub_measurement_array.publish(history)
+            case _:
+                pass

--- a/fkie_measurement_server/fkie_measurement_server/commands.py
+++ b/fkie_measurement_server/fkie_measurement_server/commands.py
@@ -29,12 +29,12 @@ class CommandManager:
         self.commandin = self.node.create_subscription(
             CommandIn, self.node.topic_command_in, self.callback_command, 5
         )
-        self.node.get_logger().info(f"Subscribed to {self.commandin.topic_name}")
+        self.node.get_logger().info(f" Subscribed to {self.commandin.topic_name}")
 
         self.commandout = self.node.create_publisher(
             CommandOut, self.node.topic_command_out, 5
         )
-        self.node.get_logger().info(f"Advertising to {self.commandout.topic_name}")
+        self.node.get_logger().info(f" Advertising to {self.commandout.topic_name}")
 
         self.node.get_logger().info("Command Manager Initialized.")
 

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#  Copyright 2025 Fraunhofer FKIE - All Rights Reserved
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from rclpy.node import Node
+from typing import Dict
+import threading
+
+from fkie_measurement_msgs.msg import MeasurementArray
+from std_msgs.msg import Int32
+import tf2_ros
+
+from .subscriptions import SubscriptionManager
+from .commands import CommandManager
+
+
+class MeasurementCollectorNode(Node):
+    def __init__(self):
+
+        super(MeasurementCollectorNode, self).__init__('measurement_collector_node')
+
+        # unique_serial_id: MeasurementArray with full_history
+        self.sensor_histories: Dict[str, MeasurementArray] = {}
+
+        self.tf_buffer = tf2_ros.Buffer()
+
+        self.declare_parameter('topic_pub_measurement_array', 'measurement_array_agg')
+        self.declare_parameter('topic_sub_measurement_array', 'measurement_array')
+        self.declare_parameter('topic_command_in', 'commandin')
+        self.declare_parameter('topic_command_out', 'commandout')
+        self.declare_parameter('global_frame', 'map')
+        self.declare_parameter('utm_zone_number', 32)
+        self.declare_parameter('utm_zone_letter', 'U')
+        self.declare_parameter('topic_fix', "fix")
+
+        self.topic_pub_measurement_array = self.get_parameter('topic_pub_measurement_array').get_parameter_value().string_value
+        self.topic_sub_measurement_array = self.get_parameter('topic_sub_measurement_array').get_parameter_value().string_value
+        self.topic_command_in = self.get_parameter('topic_command_in').get_parameter_value().string_value
+        self.topic_command_out = self.get_parameter('topic_command_out').get_parameter_value().string_value
+        self.global_frame = self.get_parameter('global_frame').get_parameter_value().string_value
+        self.utm_zone_number = self.get_parameter('utm_zone_number').get_parameter_value().integer_value
+        self.utm_zone_letter = self.get_parameter('utm_zone_letter').get_parameter_value().string_value
+        self.topic_fix = self.get_parameter('topic_fix').get_parameter_value().string_value
+
+        self.get_logger().info(' ')
+        self.get_logger().info('Started with parameters:')
+        self.get_logger().info(f'  topic_pub_measurement_array: {self.topic_pub_measurement_array}')
+        self.get_logger().info(f'  topic_sub_measurement_array: {self.topic_sub_measurement_array}')
+        self.get_logger().info(f'  topic_command_in: {self.topic_command_in}')
+        self.get_logger().info(f'  topic_command_out: {self.topic_command_out}')
+        self.get_logger().info(f'  global_frame: {self.global_frame}')
+        self.get_logger().info(f'  utm_zone_number: {self.utm_zone_number}')
+        self.get_logger().info(f'  utm_zone_letter: {self.utm_zone_letter}')
+        self.get_logger().info(f'  topic_fix: {self.topic_fix}')
+        self.get_logger().info(' ')
+
+        self.pub_measurement_array = self.create_publisher(MeasurementArray, self.topic_pub_measurement_array, 5)
+        self.get_logger().info(f"Advertising to {self.pub_measurement_array.topic_name}")
+
+        self.sub_manager = SubscriptionManager(node=self)
+        self.command_manager = CommandManager(node=self)
+
+        self.get_logger().info(' ')
+
+        self.sub_client_count = self.create_subscription(Int32, '/client_count', self.callback_client_count, 5)
+
+    def peer_subscribe(self, topic_name, topic_publish, peer_publish):
+        self.get_logger().info(f"New subscription for {topic_name}")
+        msg = MeasurementArray()
+        msg.full_history = True
+        for _id, ma in self.sensor_histories.items():
+            msg.measurements.extend(ma.measurements)
+            msg.located_measurements.extend(ma.located_measurements)
+        self.pub_measurement_array.publish(msg)
+
+    def callback_client_count(self, msg):
+        if (msg.data > 0):
+            threading.Timer(3., self.peer_subscribe, ('new_client_count', None, None)).start()
+
+    def stop(self):
+        self.get_logger().info("Shutting down...")

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -25,6 +25,7 @@ import tf2_ros
 
 from .subscriptions import SubscriptionManager
 from .commands import CommandManager
+from .websocket import WebsocketManager
 
 
 class MeasurementCollectorNode(Node):
@@ -72,6 +73,7 @@ class MeasurementCollectorNode(Node):
 
         self.sub_manager = SubscriptionManager(node=self)
         self.command_manager = CommandManager(node=self)
+        self.websocket_manager = WebsocketManager(node=self)
 
         self.get_logger().info(' ')
 

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -46,6 +46,7 @@ class MeasurementCollectorNode(Node):
         self.declare_parameter('utm_zone_number', 32)
         self.declare_parameter('utm_zone_letter', 'U')
         self.declare_parameter('topic_fix', "fix")
+        self.declare_parameter('websocket_port', 8899)
 
         self.topic_pub_measurement_array = self.get_parameter('topic_pub_measurement_array').get_parameter_value().string_value
         self.topic_sub_measurement_array = self.get_parameter('topic_sub_measurement_array').get_parameter_value().string_value
@@ -55,6 +56,7 @@ class MeasurementCollectorNode(Node):
         self.utm_zone_number = self.get_parameter('utm_zone_number').get_parameter_value().integer_value
         self.utm_zone_letter = self.get_parameter('utm_zone_letter').get_parameter_value().string_value
         self.topic_fix = self.get_parameter('topic_fix').get_parameter_value().string_value
+        self.websocket_port = self.get_parameter('websocket_port').get_parameter_value().integer_value
 
         self.get_logger().info(' ')
         self.get_logger().info('Started with parameters:')
@@ -66,6 +68,7 @@ class MeasurementCollectorNode(Node):
         self.get_logger().info(f'  utm_zone_number: {self.utm_zone_number}')
         self.get_logger().info(f'  utm_zone_letter: {self.utm_zone_letter}')
         self.get_logger().info(f'  topic_fix: {self.topic_fix}')
+        self.get_logger().info(f'  websocket port: {self.websocket_port}')
         self.get_logger().info(' ')
 
         self.pub_measurement_array = self.create_publisher(MeasurementArray, self.topic_pub_measurement_array, 5)
@@ -73,7 +76,7 @@ class MeasurementCollectorNode(Node):
 
         self.sub_manager = SubscriptionManager(node=self)
         self.command_manager = CommandManager(node=self)
-        self.websocket_manager = WebsocketManager(node=self)
+        self.websocket_manager = WebsocketManager(node=self, port=self.websocket_port)
 
         self.get_logger().info(' ')
 

--- a/fkie_measurement_server/fkie_measurement_server/subscriptions.py
+++ b/fkie_measurement_server/fkie_measurement_server/subscriptions.py
@@ -30,19 +30,19 @@ class SubscriptionManager():
         self.node.get_logger().info('Initializing Subscription Manager...')
 
         self.sub_m = self.node.create_subscription(Measurement, '/in_measurement', self.callback_measurement, 5)
-        self.node.get_logger().info(f"Subscribed to {self.sub_m.topic_name}")
+        self.node.get_logger().info(f" Subscribed to {self.sub_m.topic_name}")
 
         self.sub_m_located = self.node.create_subscription(
             MeasurementLocated, '/in_measurement_located', self.callback_measurement_located, 5)
-        self.node.get_logger().info(f"Subscribed to {self.sub_m_located.topic_name}")
+        self.node.get_logger().info(f" Subscribed to {self.sub_m_located.topic_name}")
 
         self.sub_m_array = self.node.create_subscription(
             MeasurementArray, self.node.topic_sub_measurement_array, self.callback_measurement_array, 5)
-        self.node.get_logger().info(f"Subscribed to {self.sub_m_array.topic_name}")
+        self.node.get_logger().info(f" Subscribed to {self.sub_m_array.topic_name}")
 
         if self.node.topic_fix:
             self.topic_sub_fix = self.node.create_subscription(NavSatFix, self.node.topic_fix, self.cb_fix, 5)
-            self.node.get_logger().info(f"Subscribed to {self.topic_sub_fix.topic_name}")
+            self.node.get_logger().info(f" Subscribed to {self.topic_sub_fix.topic_name}")
 
         self.node.get_logger().info('Subscription Manager Initialized.')
 

--- a/fkie_measurement_server/fkie_measurement_server/subscriptions.py
+++ b/fkie_measurement_server/fkie_measurement_server/subscriptions.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#  Copyright 2025 Fraunhofer FKIE - All Rights Reserved
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from fkie_measurement_msgs.msg import Measurement, MeasurementArray, MeasurementLocated
+from sensor_msgs.msg import NavSatFix
+from geodesy import utm
+from typing import Set
+import tf2_ros
+
+
+class SubscriptionManager():
+    def __init__(self, node=None):
+        self.node = node
+
+        self.node.get_logger().info(' ')
+        self.node.get_logger().info('Initializing Subscription Manager...')
+
+        self.sub_m = self.node.create_subscription(Measurement, '/in_measurement', self.callback_measurement, 5)
+        self.node.get_logger().info(f"Subscribed to {self.sub_m.topic_name}")
+
+        self.sub_m_located = self.node.create_subscription(
+            MeasurementLocated, '/in_measurement_located', self.callback_measurement_located, 5)
+        self.node.get_logger().info(f"Subscribed to {self.sub_m_located.topic_name}")
+
+        self.sub_m_array = self.node.create_subscription(
+            MeasurementArray, self.node.topic_sub_measurement_array, self.callback_measurement_array, 5)
+        self.node.get_logger().info(f"Subscribed to {self.sub_m_array.topic_name}")
+
+        if self.node.topic_fix:
+            self.topic_sub_fix = self.node.create_subscription(NavSatFix, self.node.topic_fix, self.cb_fix, 5)
+            self.node.get_logger().info(f"Subscribed to {self.topic_sub_fix.topic_name}")
+
+        self.node.get_logger().info('Subscription Manager Initialized.')
+
+    def callback_measurement(self, msg):
+        if not msg.unique_serial_id:
+            self.node.get_logger().error(
+                "[callback_measurement] empty [unique_serial_id]."
+            )
+            return
+
+        if msg.unique_serial_id not in self.node.sensor_histories:
+            ma = MeasurementArray()
+            ma.full_history = True
+            self.node.sensor_histories[msg.unique_serial_id] = ma
+
+        s_history: MeasurementArray = self.node.sensor_histories[msg.unique_serial_id]
+        msg_loc = MeasurementLocated()
+        msg_loc.measurement = msg
+
+        try:
+            trans = self.node.tf_buffer.lookup_transform(
+                self.node.global_frame, msg.header.frame_id, self.node.get_clock().now()
+            )
+            # get current position
+            msg_loc.pose.pose.position.x = trans.transform.translation.x
+            msg_loc.pose.pose.position.y = trans.transform.translation.y
+            msg_loc.pose.pose.position.z = trans.transform.translation.z
+            msg_loc.pose.header.frame_id = trans.header.frame_id
+            msg_loc.pose.header.stamp = trans.header.stamp
+            s_history.located_measurements.append(msg_loc)
+            if self.node.utm_zone_number and self.node.utm_zone_letter:
+                msg_loc.utm_zone_number = self.node.utm_zone_number
+                msg_loc.utm_zone_letter = self.node.utm_zone_letter
+        except (
+            tf2_ros.LookupException,
+            tf2_ros.ConnectivityException,
+            tf2_ros.ExtrapolationException,
+        ):
+            self.node.get_logger().info(
+                "[callback_measurement] Could not find TF2 lookup between frames [{0}] and [{1}]".format(
+                    self.global_frame, msg.header.frame_id
+                )
+            )
+            return
+        msg_array = MeasurementArray()
+        msg_array.full_history = False
+        msg_array.located_measurements.append(msg_loc)
+        self.node.pub_measurement_array.publish(msg_array)
+
+    def callback_measurement_located(self, msg):
+        if not msg.measurement.unique_serial_id:
+            self.node.get_logger().error(
+                "[callback_measurement_located] empty [unique_serial_id]."
+            )
+            return
+
+        if msg.measurement.unique_serial_id not in self.node.sensor_histories:
+            ma = MeasurementArray()
+            ma.full_history = True
+            self.node.sensor_histories[msg.measurement.unique_serial_id] = ma
+
+        s_history: MeasurementArray = self.node.sensor_histories[
+            msg.measurement.unique_serial_id
+        ]
+        s_history.located_measurements.append(msg)
+
+        msg_array = MeasurementArray()
+        msg_array.full_history = False
+        msg_array.located_measurements.append(msg)
+        self.node.pub_measurement_array.publish(msg_array)
+
+    def callback_measurement_array(self, msg):
+        # clear if this message has full history
+        if msg.full_history:
+            ids: Set[str] = set()
+            for item in msg.measurements:
+                ids.add(item.unique_serial_id)
+            for item in msg.located_measurements:
+                ids.add(item.measurement.unique_serial_id)
+            for id in ids:
+                if id in self.node.sensor_histories:
+                    del self.node.sensor_histories[id]
+    
+        # add to history
+        for item in msg.measurements:
+            self.callback_measurement(item)
+    
+        for item in msg.located_measurements:
+            self.callback_measurement_located(item)
+        self.node.pub_measurement_array.publish(msg)
+
+    def cb_fix(self, msg):
+        utm_point = utm.fromLatLong(
+            msg.latitude, msg.longitude, msg.altitude)
+        if utm_point.valid():
+            self.fix_timestamp = msg.header.stamp
+            self.utm_position = utm_point

--- a/fkie_measurement_server/fkie_measurement_server/websocket.py
+++ b/fkie_measurement_server/fkie_measurement_server/websocket.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#  Copyright 2025 Fraunhofer FKIE - All Rights Reserved
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from fkie_measurement_msgs.msg import MeasurementValue, MeasurementArray, MeasurementLocated
+
+from threading import Thread
+import websockets
+import asyncio
+import json
+
+
+class WebsocketManager():
+    def __init__(self, node=None):
+        self.node = node
+        self.websocket = None
+        self.loop = asyncio.new_event_loop()
+
+        self.node.get_logger().info(' ')
+        self.node.get_logger().info('Starting Websocket...')
+
+        self.thread = Thread(target=self.run_server, daemon=True)
+        self.thread.start()
+
+        self.node.get_logger().info('Websocket started successfully.')
+
+    def run_server(self):
+        asyncio.set_event_loop(self.loop)
+        self.websocket = websockets.serve(self.handler, 'localhost', 8899)
+
+        # this is misleading, as this only creates the websocket server but does not run it
+        # it converts the websockets.legacy.server.Serve class into a Future and awaits its completion
+        self.loop.run_until_complete(self.websocket)
+
+        # this actually starts the server
+        self.loop.run_forever()
+        self.loop.close()
+
+    async def handler(self, websocket):
+        try:
+            while True:
+                message = await websocket.recv()
+                self.handle_message(message)
+        except websockets.exceptions.ConnectionClosedOK:
+            self.node.get_logger().info('Websocket closed gracefully')
+
+    def handle_message(self, message):
+        try:
+            json_data = json.loads(message)
+
+            if not json_data['unique_serial_id']:
+                self.node.get_logger().error(
+                    "[callback_measurement] empty [unique_serial_id]."
+                )
+                return
+            
+            if json_data['unique_serial_id'] not in self.node.sensor_histories:
+                ma = MeasurementArray()
+                ma.full_history = True
+                self.node.sensor_histories[json_data['unique_serial_id']] = ma
+
+            s_history: MeasurementArray = self.node.sensor_histories[json_data['unique_serial_id']]
+
+            # Located Measurement
+            msg_loc = MeasurementLocated()
+            msg_loc.pose.pose.position.x = float(json_data['position']['x'])
+            msg_loc.pose.pose.position.y = float(json_data['position']['y'])
+            msg_loc.pose.pose.position.z = float(json_data['position']['z'])
+            msg_loc.pose.pose.orientation.x = float(json_data['orientation']['x'])
+            msg_loc.pose.pose.orientation.y = float(json_data['orientation']['y'])
+            msg_loc.pose.pose.orientation.z = float(json_data['orientation']['z'])
+            msg_loc.pose.pose.orientation.w = float(json_data['orientation']['w'])
+            msg_loc.pose.header.frame_id = json_data['frame_id']
+            msg_loc.pose.header.stamp.sec = int(json_data['stamp']['sec'])
+            msg_loc.pose.header.stamp.nanosec = int(json_data['stamp']['nanosec'])
+            msg_loc.measurement.header.frame_id = json_data['frame_id']
+            msg_loc.measurement.header.stamp.sec = int(json_data['stamp']['sec'])
+            msg_loc.measurement.header.stamp.nanosec = int(json_data['stamp']['nanosec'])
+            msg_loc.measurement.unique_serial_id = json_data['unique_serial_id']
+            msg_loc.measurement.manufacturer_device_name = json_data['manufacturer_device_name']
+            msg_loc.measurement.device_classification = json_data['device_classification']
+
+            if self.node.utm_zone_number and self.node.utm_zone_letter:
+                msg_loc.utm_zone_number = self.node.utm_zone_number
+                msg_loc.utm_zone_letter = self.node.utm_zone_letter
+
+            s_history.located_measurements.append(msg_loc)
+
+            # Measurement Value
+            msg_value = MeasurementValue()
+            msg_value.begin.sec = int(json_data['stamp']['sec'])
+            msg_value.begin.nanosec = int(json_data['stamp']['nanosec'])
+            msg_value.end.sec = int(json_data['stamp']['sec'])
+            msg_value.end.nanosec = int(json_data['stamp']['nanosec'])
+            msg_value.sensor = json_data['sensor']
+            msg_value.source_type = json_data['source_type']
+            msg_value.unit = json_data['unit']
+            msg_value.value_single = float(json_data['value'])
+            msg_loc.measurement.values.append(msg_value)
+
+            # Final Message
+            msg_array = MeasurementArray()
+            msg_array.full_history = False
+            msg_array.located_measurements.append(msg_loc)
+
+            self.node.pub_measurement_array.publish(msg_array)
+
+        except Exception as error:
+            self.node.get_logger().warn(f'Could not parse message: {message}')
+            self.node.get_logger().warn(f'Error: {error}')
+        
+
+'''
+Websocket JSON Format:
+{
+    frame_id: string
+    stamp: {
+        sec: number
+        nanosec: number
+    }
+    position: {
+        x: number
+        y: number
+        z: number
+    }
+    orientation: {
+        x: number
+        y: number
+        z: number
+        w: number
+    }
+    utm_zone_number: number
+    utm_zone_letter: string
+    unique_serial_id: string
+    manufacturer_device_name: string
+    device_classification: string
+    sensor: string
+    source_type: string
+    unit: string
+    value: number
+}
+
+Test JSON:
+{
+    "frame_id": "world",
+    "stamp": {
+        "sec": 5000,
+        "nanosec": 5000
+    },
+    "position": {
+        "x": 366188,
+        "y": 5609559,
+        "z": 255
+    },
+    "orientation": {
+        "x": 0,
+        "y": 0,
+        "z": 0,
+        "w": 1
+    },
+    "utm_zone_number": 32,
+    "utm_zone_letter": "U",
+    "unique_serial_id": "T-4000",
+    "manufacturer_device_name": "Terminator Modell 4000",
+    "device_classification": "T",
+    "sensor": "threat-level",
+    "source_type": "visual",
+    "unit": "of 10",
+    "value": 6
+}
+
+{"frame_id":"world","stamp":{"sec":5000,"nanosec":5000},"position":{"x":366188,"y":5609559,"z":255},"orientation":{"x":0,"y":0,"z":0,"w":1},"utm_zone_number":32,"utm_zone_letter":"U","unique_serial_id":"T-4000","manufacturer_device_name":"Terminator Modell 4000","device_classification":"T","sensor":"threat-level","source_type":"visual","unit":"of 10","value":6}
+'''

--- a/fkie_measurement_server/fkie_measurement_server/websocket.py
+++ b/fkie_measurement_server/fkie_measurement_server/websocket.py
@@ -24,9 +24,10 @@ import json
 
 
 class WebsocketManager():
-    def __init__(self, node=None):
+    def __init__(self, node=None, port=8899):
         self.node = node
         self.websocket = None
+        self.websocket_port = port
         self.loop = asyncio.new_event_loop()
 
         self.node.get_logger().info(' ')
@@ -39,7 +40,7 @@ class WebsocketManager():
 
     def run_server(self):
         asyncio.set_event_loop(self.loop)
-        self.websocket = websockets.serve(self.handler, 'localhost', 8899)
+        self.websocket = websockets.serve(self.handler, 'localhost', self.websocket_port)
 
         # this is misleading, as this only creates the websocket server but does not run it
         # it converts the websockets.legacy.server.Serve class into a Future and awaits its completion
@@ -55,7 +56,7 @@ class WebsocketManager():
                 message = await websocket.recv()
                 self.handle_message(message)
         except websockets.exceptions.ConnectionClosedOK:
-            self.node.get_logger().info('Websocket closed gracefully')
+            pass
 
     def handle_message(self, message):
         try:


### PR DESCRIPTION
This PR implements a websocket capable of receiving measurement messages and broadcasting those on the default ROS publishing topic. 
The expected JSON format can be found [here](https://github.com/S1lencio/measurement_server/blob/ba6a84baaeef3c65727e5e7131594621d827b239/fkie_measurement_server/fkie_measurement_server/websocket.py#L127-L187)

The default port is `8899`. This can be configured using a launch file param.

To maintain readability, the node has been split into multiple python files. 