### PR TITLE
Implement webserver to receive measurement messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode
 __pycache__
+
+# Intellij IDEs
+.idea/

--- a/fkie_measurement_server/fkie_measurement_server/commands.py
+++ b/fkie_measurement_server/fkie_measurement_server/commands.py
@@ -20,6 +20,9 @@ from fkie_measurement_msgs.msg import MeasurementArray
 
 
 class CommandManager:
+    """
+    A simple framework to receive commands from connected clients.
+    """
     def __init__(self, node=None):
         self.node = node
 
@@ -39,6 +42,9 @@ class CommandManager:
         self.node.get_logger().info("Command Manager Initialized.")
 
     def callback_command(self, msg):
+        """
+        Method called when a command is received
+        """
         self.node.get_logger().info(f"Command called: {msg.command}")
         match msg.command:
             case "history":

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -19,9 +19,10 @@ from rclpy.node import Node
 from typing import Dict
 import threading
 
-from fkie_measurement_msgs.msg import MeasurementArray
+from fkie_measurement_msgs.msg import MeasurementValue, MeasurementArray, MeasurementLocated
 from std_msgs.msg import Int32
 import tf2_ros
+import time
 
 from .subscriptions import SubscriptionManager
 from .commands import CommandManager
@@ -80,8 +81,8 @@ class MeasurementCollectorNode(Node):
 
         self.sub_manager = SubscriptionManager(node=self)
         self.command_manager = CommandManager(node=self)
-        self.websocket_manager = WebsocketManager(node=self, port=self.websocket_port)
-        self.webserver_manager = WebServerManager(node=self, port=self.webserver_port)
+        self.websocket_manager = WebsocketManager(node=self, port=self.websocket_port, method=self.create_message)
+        self.webserver_manager = WebServerManager(node=self, port=self.webserver_port, method=self.create_message)
 
         self.get_logger().info(' ')
 
@@ -102,3 +103,115 @@ class MeasurementCollectorNode(Node):
 
     def stop(self):
         self.get_logger().info("Shutting down...")
+
+    def create_message(self, data, type):
+        # extract json parameters
+        frame_id = data.get('frame_id')  # optional
+        stamp_sec = data.get('stamp_sec')  # optional
+        stamp_nanosec = data.get('stamp_nanosec')  # optional
+        position_x = data.get('position_x')  # optional
+        position_y = data.get('position_y')  # optional
+        position_z = data.get('position_z')  # optional
+        orientation_x = data.get('orientation_x')  # optional
+        orientation_y = data.get('orientation_y')  # optional
+        orientation_z = data.get('orientation_z')  # optional
+        orientation_w = data.get('orientation_w')  # optional
+        utm_zone_number = data.get('utm_zone_number')  # optional
+        utm_zone_letter = data.get('utm_zone_letter')  # optional
+        unique_serial_id = data.get('unique_serial_id')  # required
+        manufacturer_device_name = data.get('manufacturer_device_name')  # required
+        device_classification = data.get('device_classification')  # required
+        sensor = data.get('sensor')  # required
+        source_type = data.get('source_type')  # required
+        unit = data.get('unit')  # required
+        value = data.get('value')  # required
+
+        if not(manufacturer_device_name and device_classification and sensor and source_type and unit and value):
+            self.get_logger().warn(
+                f"[{type}] Required fields missing."
+            )
+            return
+            
+        if unique_serial_id not in self.sensor_histories:
+            ma = MeasurementArray()
+            ma.full_history = True
+            self.sensor_histories[unique_serial_id] = ma
+
+        s_history: MeasurementArray = self.sensor_histories[unique_serial_id]
+
+        # Located Measurement
+        msg_loc = MeasurementLocated()
+        if position_x and position_y and position_x:
+            msg_loc.pose.pose.position.x = float(position_x)
+            msg_loc.pose.pose.position.y = float(position_y)
+            msg_loc.pose.pose.position.z = float(position_z)
+        else:
+            msg_loc.pose.pose.position.x = 0.0
+            msg_loc.pose.pose.position.y = 0.0
+            msg_loc.pose.pose.position.z = 0.0
+
+        if orientation_w and orientation_x and orientation_y and orientation_z:
+            msg_loc.pose.pose.orientation.x = float(orientation_x)
+            msg_loc.pose.pose.orientation.y = float(orientation_y)
+            msg_loc.pose.pose.orientation.z = float(orientation_z)
+            msg_loc.pose.pose.orientation.w = float(orientation_w)
+        else:
+            msg_loc.pose.pose.orientation.x = 0.0
+            msg_loc.pose.pose.orientation.y = 0.0
+            msg_loc.pose.pose.orientation.z = 0.0
+            msg_loc.pose.pose.orientation.w = 1.0
+
+        if stamp_sec and stamp_nanosec:
+            msg_loc.pose.header.stamp.sec = int(stamp_sec)
+            msg_loc.pose.header.stamp.nanosec = int(stamp_nanosec)
+            msg_loc.measurement.header.stamp.sec = int(stamp_sec)
+            msg_loc.measurement.header.stamp.nanosec = int(stamp_nanosec)
+        else:
+            msg_loc.pose.header.stamp.sec = int(time.time())
+            msg_loc.pose.header.stamp.nanosec = 0
+            msg_loc.measurement.header.stamp.sec = int(time.time())
+            msg_loc.measurement.header.stamp.nanosec = 0
+
+        if frame_id:
+            msg_loc.pose.header.frame_id = frame_id
+            msg_loc.measurement.header.frame_id = frame_id
+        else: 
+            msg_loc.pose.header.frame_id = ""
+            msg_loc.measurement.header.frame_id = ""
+
+        msg_loc.measurement.unique_serial_id = unique_serial_id
+        msg_loc.measurement.manufacturer_device_name = manufacturer_device_name
+        msg_loc.measurement.device_classification = device_classification
+
+        if self.utm_zone_number and self.utm_zone_letter:
+            msg_loc.utm_zone_number = self.utm_zone_number
+            msg_loc.utm_zone_letter = self.utm_zone_letter
+
+        s_history.located_measurements.append(msg_loc)
+
+        # Measurement Value
+        msg_value = MeasurementValue()
+
+        if stamp_sec and stamp_nanosec:
+            msg_value.begin.sec = int(stamp_sec)
+            msg_value.begin.nanosec = int(stamp_nanosec)
+            msg_value.end.sec = int(stamp_sec)
+            msg_value.end.nanosec = int(stamp_nanosec)
+        else:
+            msg_value.begin.sec = int(time.time())
+            msg_value.begin.nanosec = 0
+            msg_value.end.sec = int(time.time())
+            msg_value.end.nanosec = 0
+
+        msg_value.sensor = sensor
+        msg_value.source_type = source_type
+        msg_value.unit = unit
+        msg_value.value_single = float(value)
+        msg_loc.measurement.values.append(msg_value)
+
+        # Final Message
+        msg_array = MeasurementArray()
+        msg_array.full_history = False
+        msg_array.located_measurements.append(msg_loc)
+
+        self.pub_measurement_array.publish(msg_array)

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -31,7 +31,13 @@ from .websocket import WebsocketManager
 
 
 class MeasurementCollectorNode(Node):
+    """
+    A ROS node to collect measurement data from ROS Topics, websockets and POST requests
+    """
     def __init__(self):
+        """
+        Initialize the Node and start its managers
+        """
 
         super(MeasurementCollectorNode, self).__init__('measurement_collector_node')
 
@@ -89,7 +95,11 @@ class MeasurementCollectorNode(Node):
         self.sub_client_count = self.create_subscription(Int32, '/client_count', self.callback_client_count, 5)
 
     def peer_subscribe(self, topic_name, topic_publish, peer_publish):
+        """
+        Send sensor history to topic_pub_measurement_array
+        """
         self.get_logger().info(f"New subscription for {topic_name}")
+
         msg = MeasurementArray()
         msg.full_history = True
         for _id, ma in self.sensor_histories.items():
@@ -98,13 +108,22 @@ class MeasurementCollectorNode(Node):
         self.pub_measurement_array.publish(msg)
 
     def callback_client_count(self, msg):
+        """
+        Called when a new client (subscriber) is found on the topic_pub_measurement_array topic
+        """
         if (msg.data > 0):
             threading.Timer(3., self.peer_subscribe, ('new_client_count', None, None)).start()
 
     def stop(self):
+        """
+        Shut down the node, threads are stopped instantly as they are daemons
+        """
         self.get_logger().info("Shutting down...")
 
     def create_message(self, data, type):
+        """
+        Function to extract, parse and publish measurements
+        """
         # extract json parameters
         frame_id = data.get('frame_id')  # optional
         stamp_sec = data.get('stamp_sec')  # optional

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -25,6 +25,7 @@ import tf2_ros
 
 from .subscriptions import SubscriptionManager
 from .commands import CommandManager
+from .webserver import WebServerManager
 from .websocket import WebsocketManager
 
 
@@ -47,6 +48,7 @@ class MeasurementCollectorNode(Node):
         self.declare_parameter('utm_zone_letter', 'U')
         self.declare_parameter('topic_fix', "fix")
         self.declare_parameter('websocket_port', 8899)
+        self.declare_parameter('webserver_port', 8080)
 
         self.topic_pub_measurement_array = self.get_parameter('topic_pub_measurement_array').get_parameter_value().string_value
         self.topic_sub_measurement_array = self.get_parameter('topic_sub_measurement_array').get_parameter_value().string_value
@@ -57,6 +59,7 @@ class MeasurementCollectorNode(Node):
         self.utm_zone_letter = self.get_parameter('utm_zone_letter').get_parameter_value().string_value
         self.topic_fix = self.get_parameter('topic_fix').get_parameter_value().string_value
         self.websocket_port = self.get_parameter('websocket_port').get_parameter_value().integer_value
+        self.webserver_port = self.get_parameter('webserver_port').get_parameter_value().integer_value
 
         self.get_logger().info(' ')
         self.get_logger().info('Started with parameters:')
@@ -69,6 +72,7 @@ class MeasurementCollectorNode(Node):
         self.get_logger().info(f'  utm_zone_letter: {self.utm_zone_letter}')
         self.get_logger().info(f'  topic_fix: {self.topic_fix}')
         self.get_logger().info(f'  websocket port: {self.websocket_port}')
+        self.get_logger().info(f'  webserver port: {self.webserver_port}')
         self.get_logger().info(' ')
 
         self.pub_measurement_array = self.create_publisher(MeasurementArray, self.topic_pub_measurement_array, 5)
@@ -77,6 +81,7 @@ class MeasurementCollectorNode(Node):
         self.sub_manager = SubscriptionManager(node=self)
         self.command_manager = CommandManager(node=self)
         self.websocket_manager = WebsocketManager(node=self, port=self.websocket_port)
+        self.webserver_manager = WebServerManager(node=self, port=self.webserver_port)
 
         self.get_logger().info(' ')
 

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -141,11 +141,11 @@ class MeasurementCollectorNode(Node):
         manufacturer_device_name = data.get('manufacturer_device_name')  # optional
         device_classification = data.get('device_classification')  # optional
         sensor = data.get('sensor')  # required
-        source_type = data.get('source_type')  # required
-        unit = data.get('unit')  # required
+        source_type = data.get('source_type')  # optional
+        unit = data.get('unit')  # optional
         value = data.get('value')  # required
 
-        if not(unique_serial_id and sensor and source_type and unit and value):
+        if not(unique_serial_id and sensor and value):
             self.get_logger().warn(
                 f"[{type}] Required fields missing."
             )
@@ -156,6 +156,12 @@ class MeasurementCollectorNode(Node):
 
         if not device_classification:
             device_classification = ""
+        
+        if not source_type:
+            source_type = ""
+
+        if not unit:
+            unit = ""
             
         if unique_serial_id not in self.sensor_histories:
             ma = MeasurementArray()

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -126,7 +126,7 @@ class MeasurementCollectorNode(Node):
         unit = data.get('unit')  # required
         value = data.get('value')  # required
 
-        if not(manufacturer_device_name and device_classification and sensor and source_type and unit and value):
+        if not(unique_serial_id and manufacturer_device_name and device_classification and sensor and source_type and unit and value):
             self.get_logger().warn(
                 f"[{type}] Required fields missing."
             )

--- a/fkie_measurement_server/fkie_measurement_server/measurement_server.py
+++ b/fkie_measurement_server/fkie_measurement_server/measurement_server.py
@@ -138,18 +138,24 @@ class MeasurementCollectorNode(Node):
         utm_zone_number = data.get('utm_zone_number')  # optional
         utm_zone_letter = data.get('utm_zone_letter')  # optional
         unique_serial_id = data.get('unique_serial_id')  # required
-        manufacturer_device_name = data.get('manufacturer_device_name')  # required
-        device_classification = data.get('device_classification')  # required
+        manufacturer_device_name = data.get('manufacturer_device_name')  # optional
+        device_classification = data.get('device_classification')  # optional
         sensor = data.get('sensor')  # required
         source_type = data.get('source_type')  # required
         unit = data.get('unit')  # required
         value = data.get('value')  # required
 
-        if not(unique_serial_id and manufacturer_device_name and device_classification and sensor and source_type and unit and value):
+        if not(unique_serial_id and sensor and source_type and unit and value):
             self.get_logger().warn(
                 f"[{type}] Required fields missing."
             )
             return
+        
+        if not manufacturer_device_name:
+            manufacturer_device_name = unique_serial_id
+
+        if not device_classification:
+            device_classification = ""
             
         if unique_serial_id not in self.sensor_histories:
             ma = MeasurementArray()

--- a/fkie_measurement_server/fkie_measurement_server/subscriptions.py
+++ b/fkie_measurement_server/fkie_measurement_server/subscriptions.py
@@ -22,7 +22,7 @@ from typing import Set
 import tf2_ros
 
 
-class SubscriptionManager():
+class SubscriptionManager:
     def __init__(self, node=None):
         self.node = node
 

--- a/fkie_measurement_server/fkie_measurement_server/subscriptions.py
+++ b/fkie_measurement_server/fkie_measurement_server/subscriptions.py
@@ -23,7 +23,13 @@ import tf2_ros
 
 
 class SubscriptionManager:
+    """
+    Manage subscriptions for the measurement collector
+    """
     def __init__(self, node=None):
+        """
+        Create subscriptions to measurement topics
+        """
         self.node = node
 
         self.node.get_logger().info(' ')
@@ -47,6 +53,9 @@ class SubscriptionManager:
         self.node.get_logger().info('Subscription Manager Initialized.')
 
     def callback_measurement(self, msg):
+        """
+        Method called when a measurement is received on /in_measurement 
+        """
         if not msg.unique_serial_id:
             self.node.get_logger().error(
                 "[callback_measurement] empty [unique_serial_id]."
@@ -93,6 +102,9 @@ class SubscriptionManager:
         self.node.pub_measurement_array.publish(msg_array)
 
     def callback_measurement_located(self, msg):
+        """
+        Method called when a measurement is received on /in_measurement_located 
+        """
         if not msg.measurement.unique_serial_id:
             self.node.get_logger().error(
                 "[callback_measurement_located] empty [unique_serial_id]."
@@ -115,6 +127,9 @@ class SubscriptionManager:
         self.node.pub_measurement_array.publish(msg_array)
 
     def callback_measurement_array(self, msg):
+        """
+        Method called when a measurement is received on topic_sub_measurement_array 
+        """
         # clear if this message has full history
         if msg.full_history:
             ids: Set[str] = set()

--- a/fkie_measurement_server/fkie_measurement_server/webserver.py
+++ b/fkie_measurement_server/fkie_measurement_server/webserver.py
@@ -1,0 +1,122 @@
+from threading import Thread
+
+from flask import Flask, jsonify, request
+from fkie_measurement_msgs.msg import MeasurementValue, MeasurementArray, MeasurementLocated
+
+
+class WebServerManager:
+    """
+    A simple web server to receive measurement data via HTTP POST requests.
+    """
+    def __init__(self, node=None, port=8080):
+        """
+        Initialize the web server and start it on a separate thread.
+        """
+        self.node = node
+        self.port = port
+
+        self.app = Flask(__name__)
+
+        # This is a bit confusing, '/' is the actual route, 'receive_measurement' is just the name of the method
+        self.app.add_url_rule('/', 'receive_measurement', self.receive_measurement, methods=['POST'])
+
+        self.node.get_logger().info(' ')
+        self.node.get_logger().info('Starting Webserver...')
+
+        self.thread = Thread(target=self.start, daemon=True)
+        self.thread.start()
+
+        self.node.get_logger().info('Webserver started successfully.')
+
+    def start(self):
+        """
+        Start the Flask web server.
+        """
+        self.app.run(port=self.port)
+
+    def receive_measurement(self):
+        """
+        Endpoint to receive measurement data.
+        """
+        try:
+            # extract query parameters
+            # because we use request.args[] instead of request.args.get(), it will immediately throw an error if a value is missing
+            frame_id = request.args['frame_id']
+            stamp_sec = request.args['stamp_sec']
+            stamp_nanosec = request.args['stamp_nanosec']
+            position_x = request.args['position_x']
+            position_y = request.args['position_y']
+            position_z = request.args['position_z']
+            orientation_x = request.args['orientation_x']
+            orientation_y = request.args['orientation_y']
+            orientation_z = request.args['orientation_z']
+            orientation_w = request.args['orientation_w']
+            utm_zone_number = request.args['utm_zone_number']
+            utm_zone_letter = request.args['utm_zone_letter']
+            unique_serial_id = request.args['unique_serial_id']
+            manufacturer_device_name = request.args['manufacturer_device_name']
+            device_classification = request.args['device_classification']
+            sensor = request.args['sensor']
+            source_type = request.args['source_type']
+            unit = request.args['unit']
+            value = request.args['value']
+
+            if unique_serial_id not in self.node.sensor_histories:
+                ma = MeasurementArray()
+                ma.full_history = True
+                self.node.sensor_histories[unique_serial_id] = ma
+
+            s_history: MeasurementArray = self.node.sensor_histories[unique_serial_id]
+
+            # Located Measurement
+            msg_loc = MeasurementLocated()
+            msg_loc.pose.pose.position.x = float(position_x)
+            msg_loc.pose.pose.position.y = float(position_y)
+            msg_loc.pose.pose.position.z = float(position_z)
+            msg_loc.pose.pose.orientation.x = float(orientation_x)
+            msg_loc.pose.pose.orientation.y = float(orientation_y)
+            msg_loc.pose.pose.orientation.z = float(orientation_z)
+            msg_loc.pose.pose.orientation.w = float(orientation_w)
+            msg_loc.pose.header.frame_id = frame_id
+            msg_loc.pose.header.stamp.sec = int(stamp_sec)
+            msg_loc.pose.header.stamp.nanosec = int(stamp_nanosec)
+            msg_loc.measurement.header.frame_id = frame_id
+            msg_loc.measurement.header.stamp.sec = int(stamp_sec)
+            msg_loc.measurement.header.stamp.nanosec = int(stamp_nanosec)
+            msg_loc.measurement.unique_serial_id = unique_serial_id
+            msg_loc.measurement.manufacturer_device_name = manufacturer_device_name
+            msg_loc.measurement.device_classification = device_classification
+
+            if self.node.utm_zone_number and self.node.utm_zone_letter:
+                msg_loc.utm_zone_number = self.node.utm_zone_number
+                msg_loc.utm_zone_letter = self.node.utm_zone_letter
+
+            s_history.located_measurements.append(msg_loc)
+
+            # Measurement Value
+            msg_value = MeasurementValue()
+            msg_value.begin.sec = int(stamp_sec)
+            msg_value.begin.nanosec = int(stamp_nanosec)
+            msg_value.end.sec = int(stamp_sec)
+            msg_value.end.nanosec = int(stamp_nanosec)
+            msg_value.sensor = sensor
+            msg_value.source_type = source_type
+            msg_value.unit = unit
+            msg_value.value_single = float(value)
+            msg_loc.measurement.values.append(msg_value)
+
+            # Final Message
+            msg_array = MeasurementArray()
+            msg_array.full_history = False
+            msg_array.located_measurements.append(msg_loc)
+
+            self.node.pub_measurement_array.publish(msg_array)
+
+            return jsonify({"status": "success", "message": "Measurement received"}), 200
+        except Exception as e:
+            return jsonify({"status": "error", "message": str(e)}), 500
+
+"""
+Test string:
+curl -X POST "http://localhost:8080/?frame_id=world&stamp_sec=5000&stamp_nanosec=5000&position_x=366188&position_y=5609559&position_z=255&orientation_x=0.0&orientation_y=0&orientation_z=0&orientation_w=1&utm_zone_number=32&utm_zone_letter=U&unique_serial_id=T-4000&manufacturer_device_name=Terminator%20Modell%204000&device_classification=T&sensor=threat-level&source_type=visual&unit=of%2010&value=6"
+"""

--- a/fkie_measurement_server/fkie_measurement_server/webserver.py
+++ b/fkie_measurement_server/fkie_measurement_server/webserver.py
@@ -1,20 +1,19 @@
 from threading import Thread
 
-import time
 from flask import Flask, jsonify, request
-from fkie_measurement_msgs.msg import MeasurementValue, MeasurementArray, MeasurementLocated
 
 
 class WebServerManager:
     """
     A simple web server to receive measurement data via HTTP POST requests.
     """
-    def __init__(self, node=None, port=8080):
+    def __init__(self, node=None, port=8080, method=None):
         """
         Initialize the web server and start it on a separate thread.
         """
         self.node = node
         self.port = port
+        self.create_message = method
 
         self.app = Flask(__name__)
 
@@ -45,117 +44,7 @@ class WebServerManager:
         Endpoint to receive measurement data.
         """
         try:
-            # extract query parameters
-            frame_id = request.args.get('frame_id')  # optional
-            stamp_sec = request.args.get('stamp_sec')  # optional
-            stamp_nanosec = request.args.get('stamp_nanosec')  # optional
-            position_x = request.args.get('position_x')  # optional
-            position_y = request.args.get('position_y')  # optional
-            position_z = request.args.get('position_z')  # optional
-            orientation_x = request.args.get('orientation_x')  # optional
-            orientation_y = request.args.get('orientation_y')  # optional
-            orientation_z = request.args.get('orientation_z')  # optional
-            orientation_w = request.args.get('orientation_w')  # optional
-            utm_zone_number = request.args.get('utm_zone_number')  # optional
-            utm_zone_letter = request.args.get('utm_zone_letter')  # optional
-            unique_serial_id = request.args.get('unique_serial_id')  # required
-            manufacturer_device_name = request.args.get('manufacturer_device_name')  # required
-            device_classification = request.args.get('device_classification')  # required
-            sensor = request.args.get('sensor')  # required
-            source_type = request.args.get('source_type')  # required
-            unit = request.args.get('unit')  # required
-            value = request.args.get('value')  # required
-
-            if not(manufacturer_device_name and device_classification and sensor and source_type and unit and value):
-                self.node.get_logger().warn(
-                    "[webserver] Required fields missing."
-                )
-                return jsonify({"status": "error", "message": "Required values missing."}), 400
-
-            if unique_serial_id not in self.node.sensor_histories:
-                ma = MeasurementArray()
-                ma.full_history = True
-                self.node.sensor_histories[unique_serial_id] = ma
-
-            s_history: MeasurementArray = self.node.sensor_histories[unique_serial_id]
-
-            # Located Measurement
-            msg_loc = MeasurementLocated()
-            if position_x and position_y and position_x:
-                msg_loc.pose.pose.position.x = float(position_x)
-                msg_loc.pose.pose.position.y = float(position_y)
-                msg_loc.pose.pose.position.z = float(position_z)
-            else:
-                msg_loc.pose.pose.position.x = 0.0
-                msg_loc.pose.pose.position.y = 0.0
-                msg_loc.pose.pose.position.z = 0.0
-
-            if orientation_w and orientation_x and orientation_y and orientation_z:
-                msg_loc.pose.pose.orientation.x = float(orientation_x)
-                msg_loc.pose.pose.orientation.y = float(orientation_y)
-                msg_loc.pose.pose.orientation.z = float(orientation_z)
-                msg_loc.pose.pose.orientation.w = float(orientation_w)
-            else:
-                msg_loc.pose.pose.orientation.x = 0.0
-                msg_loc.pose.pose.orientation.y = 0.0
-                msg_loc.pose.pose.orientation.z = 0.0
-                msg_loc.pose.pose.orientation.w = 1.0
-
-            if stamp_sec and stamp_nanosec:
-                msg_loc.pose.header.stamp.sec = int(stamp_sec)
-                msg_loc.pose.header.stamp.nanosec = int(stamp_nanosec)
-                msg_loc.measurement.header.stamp.sec = int(stamp_sec)
-                msg_loc.measurement.header.stamp.nanosec = int(stamp_nanosec)
-            else:
-                msg_loc.pose.header.stamp.sec = int(time.time())
-                msg_loc.pose.header.stamp.nanosec = 0
-                msg_loc.measurement.header.stamp.sec = int(time.time())
-                msg_loc.measurement.header.stamp.nanosec = 0
-
-            if frame_id:
-                msg_loc.pose.header.frame_id = frame_id
-                msg_loc.measurement.header.frame_id = frame_id
-            else: 
-                msg_loc.pose.header.frame_id = ""
-                msg_loc.measurement.header.frame_id = ""
-
-            msg_loc.measurement.unique_serial_id = unique_serial_id
-            msg_loc.measurement.manufacturer_device_name = manufacturer_device_name
-            msg_loc.measurement.device_classification = device_classification
-
-            if self.node.utm_zone_number and self.node.utm_zone_letter:
-                msg_loc.utm_zone_number = self.node.utm_zone_number
-                msg_loc.utm_zone_letter = self.node.utm_zone_letter
-
-            s_history.located_measurements.append(msg_loc)
-
-            # Measurement Value
-            msg_value = MeasurementValue()
-
-            if stamp_sec and stamp_nanosec:
-                msg_value.begin.sec = int(stamp_sec)
-                msg_value.begin.nanosec = int(stamp_nanosec)
-                msg_value.end.sec = int(stamp_sec)
-                msg_value.end.nanosec = int(stamp_nanosec)
-            else:
-                msg_value.begin.sec = int(time.time())
-                msg_value.begin.nanosec = 0
-                msg_value.end.sec = int(time.time())
-                msg_value.end.nanosec = 0
-
-            msg_value.sensor = sensor
-            msg_value.source_type = source_type
-            msg_value.unit = unit
-            msg_value.value_single = float(value)
-            msg_loc.measurement.values.append(msg_value)
-
-            # Final Message
-            msg_array = MeasurementArray()
-            msg_array.full_history = False
-            msg_array.located_measurements.append(msg_loc)
-
-            self.node.pub_measurement_array.publish(msg_array)
-
+            self.create_message(request.args, "webserver")
             return jsonify({"status": "success", "message": "Measurement received"}), 200
         except Exception as e:
             return jsonify({"status": "error", "message": str(e)}), 500

--- a/fkie_measurement_server/fkie_measurement_server/webserver.py
+++ b/fkie_measurement_server/fkie_measurement_server/webserver.py
@@ -67,6 +67,9 @@ class WebServerManager:
             value = request.args.get('value')  # required
 
             if not(manufacturer_device_name and device_classification and sensor and source_type and unit and value):
+                self.node.get_logger().warn(
+                    "[webserver] Required fields missing."
+                )
                 return jsonify({"status": "error", "message": "Required values missing."}), 400
 
             if unique_serial_id not in self.node.sensor_histories:

--- a/fkie_measurement_server/fkie_measurement_server/webserver.py
+++ b/fkie_measurement_server/fkie_measurement_server/webserver.py
@@ -54,5 +54,5 @@ Test string:
 curl -X POST "http://localhost:8080/?frame_id=world&stamp_sec=5000&stamp_nanosec=5000&position_x=366188&position_y=5609559&position_z=255&orientation_x=0.0&orientation_y=0&orientation_z=0&orientation_w=1&utm_zone_number=32&utm_zone_letter=U&unique_serial_id=T-4000&manufacturer_device_name=Terminator%20Modell%204000&device_classification=T&sensor=threat-level&source_type=visual&unit=of%2010&value=6"
 
 Minimal test string:
-curl -X POST "http://localhost:8080/?unique_serial_id=T-4000&sensor=threat-level&source_type=visual&unit=of%2010&value=6"
+curl -X POST "http://localhost:8080/?unique_serial_id=T-4000&sensor=threat-level&value=6"
 """

--- a/fkie_measurement_server/fkie_measurement_server/webserver.py
+++ b/fkie_measurement_server/fkie_measurement_server/webserver.py
@@ -54,5 +54,5 @@ Test string:
 curl -X POST "http://localhost:8080/?frame_id=world&stamp_sec=5000&stamp_nanosec=5000&position_x=366188&position_y=5609559&position_z=255&orientation_x=0.0&orientation_y=0&orientation_z=0&orientation_w=1&utm_zone_number=32&utm_zone_letter=U&unique_serial_id=T-4000&manufacturer_device_name=Terminator%20Modell%204000&device_classification=T&sensor=threat-level&source_type=visual&unit=of%2010&value=6"
 
 Minimal test string:
-curl -X POST "http://localhost:8080/?unique_serial_id=T-4000&manufacturer_device_name=Terminator%20Modell%204000&device_classification=T&sensor=threat-level&source_type=visual&unit=of%2010&value=6"
+curl -X POST "http://localhost:8080/?unique_serial_id=T-4000&sensor=threat-level&source_type=visual&unit=of%2010&value=6"
 """

--- a/fkie_measurement_server/fkie_measurement_server/webserver.py
+++ b/fkie_measurement_server/fkie_measurement_server/webserver.py
@@ -32,7 +32,12 @@ class WebServerManager:
         """
         Start the Flask web server.
         """
-        self.app.run(port=self.port)
+        # This is the development server bundled with flask
+        # self.app.run(port=self.port)
+
+        # This is a production server
+        from waitress import serve
+        serve(self.app, host="0.0.0.0", port=self.port)
 
     def receive_measurement(self):
         """

--- a/fkie_measurement_server/fkie_measurement_server/webserver.py
+++ b/fkie_measurement_server/fkie_measurement_server/webserver.py
@@ -55,5 +55,4 @@ curl -X POST "http://localhost:8080/?frame_id=world&stamp_sec=5000&stamp_nanosec
 
 Minimal test string:
 curl -X POST "http://localhost:8080/?unique_serial_id=T-4000&manufacturer_device_name=Terminator%20Modell%204000&device_classification=T&sensor=threat-level&source_type=visual&unit=of%2010&value=6"
-
 """

--- a/fkie_measurement_server/fkie_measurement_server/websocket.py
+++ b/fkie_measurement_server/fkie_measurement_server/websocket.py
@@ -23,7 +23,7 @@ import asyncio
 import json
 
 
-class WebsocketManager():
+class WebsocketManager:
     def __init__(self, node=None, port=8899):
         self.node = node
         self.websocket = None

--- a/fkie_measurement_server/fkie_measurement_server/websocket.py
+++ b/fkie_measurement_server/fkie_measurement_server/websocket.py
@@ -60,6 +60,9 @@ class WebsocketManager:
         self.loop.close()
 
     async def handler(self, websocket):
+        """
+        Websocket loop
+        """
         try:
             while True:
                 message = await websocket.recv()
@@ -68,6 +71,9 @@ class WebsocketManager:
             pass
 
     def handle_message(self, message):
+        """
+        Method to call when receiving a measurement
+        """
         try:
             json_data = json.loads(message)
             self.create_message(json_data, "websocket")
@@ -141,5 +147,4 @@ Test string:
 
 Minimal test string:
 {"unique_serial_id":"T-4000","manufacturer_device_name":"Terminator Modell 4000","device_classification":"T","sensor":"threat-level","source_type":"visual","unit":"of 10","value":6}
-
 '''

--- a/fkie_measurement_server/fkie_measurement_server/websocket.py
+++ b/fkie_measurement_server/fkie_measurement_server/websocket.py
@@ -84,9 +84,9 @@ class WebsocketManager:
             unit = json_data.get('unit')  # required
             value = json_data.get('value')  # required
 
-            if not unique_serial_id:
-                self.node.get_logger().error(
-                    "[callback_measurement] empty [unique_serial_id]."
+            if not(manufacturer_device_name and device_classification and sensor and source_type and unit and value):
+                self.node.get_logger().warn(
+                    "[websocket] Required fields missing."
                 )
                 return
             

--- a/fkie_measurement_server/fkie_measurement_server/websocket.py
+++ b/fkie_measurement_server/fkie_measurement_server/websocket.py
@@ -146,5 +146,5 @@ Test string:
 {"frame_id":"world","stamp":{"sec":5000,"nanosec":5000},"position":{"x":366188,"y":5609559,"z":255},"orientation":{"x":0,"y":0,"z":0,"w":1},"utm_zone_number":32,"utm_zone_letter":"U","unique_serial_id":"T-4000","manufacturer_device_name":"Terminator Modell 4000","device_classification":"T","sensor":"threat-level","source_type":"visual","unit":"of 10","value":6}
 
 Minimal test string:
-{"unique_serial_id":"T-4000","sensor":"threat-level","source_type":"visual","unit":"of 10","value":6}
+{"unique_serial_id":"T-4000","sensor":"threat-level","value":6}
 '''

--- a/fkie_measurement_server/fkie_measurement_server/websocket.py
+++ b/fkie_measurement_server/fkie_measurement_server/websocket.py
@@ -146,5 +146,5 @@ Test string:
 {"frame_id":"world","stamp":{"sec":5000,"nanosec":5000},"position":{"x":366188,"y":5609559,"z":255},"orientation":{"x":0,"y":0,"z":0,"w":1},"utm_zone_number":32,"utm_zone_letter":"U","unique_serial_id":"T-4000","manufacturer_device_name":"Terminator Modell 4000","device_classification":"T","sensor":"threat-level","source_type":"visual","unit":"of 10","value":6}
 
 Minimal test string:
-{"unique_serial_id":"T-4000","manufacturer_device_name":"Terminator Modell 4000","device_classification":"T","sensor":"threat-level","source_type":"visual","unit":"of 10","value":6}
+{"unique_serial_id":"T-4000","sensor":"threat-level","source_type":"visual","unit":"of 10","value":6}
 '''


### PR DESCRIPTION
This PR implements a webserver using flask and run by waitress to receive measurement messages via POST requests.

The default post is `8080`. This can be configured using a launch file param.

Additionally, non required measurement arguments have been made optional, with default values used in their place.